### PR TITLE
Install additional R pkgs

### DIFF
--- a/deployments/ohw/image/install.R
+++ b/deployments/ohw/image/install.R
@@ -7,14 +7,69 @@ install.packages("devtools")
 # This doesn't do any dependency resolution or anything,
 # so refer to `installed.packages()` for authoritative list
 cran_packages <- c(
+  "gtools", "3.8.2",
   "tidyverse", "1.3.0",
   "learnr", "0.10.1",
   "knitr", "1.29",
   "rmarkdown", "2.3",
   "Rcpp", "1.0.5",
   "reticulate", "1.16",
-  "shiny", "1.5.0"
+  "shiny", "1.5.0",
+  "itsadug", "2.3",
+  "TMB", "1.7.18",
+  "car", "3.0-10",
+  "lme4", "1.1-25",
+  "MASS", "7.3-53",
+  "MuMIn", "1.43.17",
+  "mediation", "4.5.0",
+  "nlsem", "0.8",
+  "lavaan", "0.6-7",
+  "semPlot", "1.1.2",
+  "mgcv", "1.8-33",
+  "mgcViz", "0.1.6",
+  "DHARMa", "0.3.3.0",
+  "dunn.test", "1.3.5",
+  "corrplot", "0.84",
+  "statmod", "1.4.35",
+  "tweedie", "2.3.2",
+  "glmmTMB", "1.0.2.1",
+  "data.table", "1.13.2",
+  "rgeos", "0.5-5",
+  "sf", "0.9-6",
+  "sp", "1.4-4",
+  "raster", "3.3-13",
+  "rgdal", "1.5-18",
+  "purrr", "0.3.4",
+  "ggpubr", "0.4.0",
+  "ggstance", "0.3.4",
+  "gplots", "3.1.0",
+  "gganimate", "1.0.7",
+  "splitstackshape", "1.4.8",
+  "rworldmap", "1.3-6",
+  "maptools", "1.0-2",
+  "mapdata", "2.3.0",
+  "rnaturalearth", "0.1.0",
+  "rnaturalearthdata", "0.1.0",
+  "viridis", "0.5.1",
+  "adehabitatMA", "0.3.14",
+  "ncdf4", "1.17"
 )
+
+github_packages <- c(
+  "James-Thorson-NOAA/FishStatsUtils", "2.8.0",
+  "james-thorson/EOFR", "d3ebd884e3483645a029cdf092cff986f5d8b24a",
+  "James-Thorson-NOAA/VAST", "0f7abfeed6eab96a7967cabe7f2e88a9375cef2f",
+  "3wen/legendMap", "707f00ccdc494ce3aefead7abdf0d294bd6774df"
+)
+
+devtools::install_version("INLA", "20.03.17", repos=c(getOption("repos"), INLA="https://inla.r-inla-download.org/R/stable"))
+
+for (i in seq(1, length(github_packages), 2)) {
+  devtools::install_github(
+    github_packages[i],
+    ref = github_packages[i + 1]
+  )
+}
 
 for (i in seq(1, length(cran_packages), 2)) {
   devtools::install_version(


### PR DESCRIPTION
This adds the additional R pkgs in https://github.com/2i2c-org/2i2c-pangeo-hubs/issues/2

### Some findings about some of the pkgs:
* `parallel` is part of R itself now, ref: https://community.rstudio.com/t/parallel-package-no-longer-available-in-cran/66793
* `grid` has been archived and is part of R now, ref: https://CRAN.R-project.org/package=grid
* `VAST`, `EOFR`, `INLA`, `legendMap` are not on cran
* When installing semPlot, I got this error:
```  
      downloaded length 32380 != reported length 328000
      Error: Failed to install 'unknown package' from URL:
      (converted from warning) download of package ‘gtools’ failed
```
   Installing `gtools` separately seems to have solved the issue.
*  When installing `itsadug` 2.4 (latest version), I got this error:
```
    Error in download_version_url(package, version, repos, type) : 
    version '2.4' is invalid for package 'itsadug'
```
   `itsadug` 2.3 installation went through ok.

* Had some issues when installing`VAST`, `EOFR`, `INLA` from GitHUB:
   * Ended up installing INLA separately from their website (unfortunately I forgot to save the error here)
   * There is some dependency between these pkgs + `FishStatsUtils` pkgs, and the installation froze at step:
```
testing if installed package can be loaded from temporary location
```

### Current state:
I still didn't manage to successfully build the entire image :confused: 
I managed to successfully install all the pkgs from Cran and then changed the order of installation in the `install.R` file so that the GitHub ones install first and don't wait for the others and manage to make those pass too. But now I'm now getting a weird error:
```
Fatal error: cannot create 'R_TempDir'
```
I'll try again in the moring.
@yuvipanda, if you want to give the build a try in the meantime, it would be super nice :)

**Update:** Successfully built the image :tada: 