### PR TITLE
Additional R packages

### DIFF
--- a/deployments/ohw/image/Dockerfile
+++ b/deployments/ohw/image/Dockerfile
@@ -68,7 +68,9 @@ RUN apt-get update && \
         libproj15 \
         libudunits2-0 \
         libxml2 \
-        libzmq5 > /dev/null
+        libzmq5 \
+        libglu1-mesa-dev \
+        libgl1-mesa-dev > /dev/null
 
 # Needed by RStudio
 RUN apt-get update -qq --yes && \

--- a/deployments/ohw/image/install.R
+++ b/deployments/ohw/image/install.R
@@ -55,8 +55,7 @@ cran_packages <- c(
   "ncdf4", "1.17",
   "Information", "0.0.9",
   "corrplot", "0.84",
-  "ClustOfVar", "1.1",
-  "rgl", "0.100.54"
+  "ClustOfVar", "1.1"
 )
 
 github_packages <- c(

--- a/deployments/ohw/image/install.R
+++ b/deployments/ohw/image/install.R
@@ -52,7 +52,11 @@ cran_packages <- c(
   "rnaturalearthdata", "0.1.0",
   "viridis", "0.5.1",
   "adehabitatMA", "0.3.14",
-  "ncdf4", "1.17"
+  "ncdf4", "1.17",
+  "Information", "0.0.9",
+  "corrplot", "0.84",
+  "ClustOfVar", "1.1",
+  "rgl", "0.100.54"
 )
 
 github_packages <- c(


### PR DESCRIPTION
This PR installs some additional R packages and some apt dependencies needed by `rgl` as per Yuvi's findings here: 

> For the rgl issue, I looked at the page for package rgl - https://packagemanager.rstudio.com/client/#/repos/1/packages/rgl and found that it needed a few more system packages (apt packages) to be installed. In particular, I think installing libglu1-mesa-dev and libgl1-mesa-dev should probably fix it.

Closes https://github.com/2i2c-org/pangeo-hubs/issues/9