### PR TITLE
Allow only certain GitHub orgs to login

### DIFF
--- a/deployments/farallon/config/common.yaml
+++ b/deployments/farallon/config/common.yaml
@@ -8,6 +8,10 @@ daskhub:
   jupyterhub:
     auth:
       type: github
+      github:
+        orgWhitelist:
+          - "farallon-2i2c"
+          - "2i2c-org"
       dummy:
         password: watwatwat
     proxy:

--- a/deployments/ohw/config/common.yaml
+++ b/deployments/ohw/config/common.yaml
@@ -8,6 +8,10 @@ daskhub:
   jupyterhub:
     auth:
       type: github
+      github:
+        orgWhitelist:
+          - "farallon-2i2c"
+          - "2i2c-org"
       dummy:
         password: watwatwat
     proxy:


### PR DESCRIPTION
This allows only the members of the `farallon-2i2c` and `2i2c-org` GitHub organizations to login into the hubs.
At the moment, I don't think the `farallon-2i2c` org exists, so we'll need to create it first.

Steps:
- [x] verify that the image builts ok
- [x] deploy to ohw staging and try to login with a GitHub username outside of the two organizations listed above (shouldn't work)
- [x] make sure the `farallon-2i2c` exists and has members
- [x] deploy on prod

Closes https://github.com/2i2c-org/pangeo-hubs/issues/21